### PR TITLE
Handle exceptions in ZipWithProgress.

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/ZipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/ZipWithProgress.mm
@@ -113,6 +113,12 @@
                         }
                         @catch (NSException *exception)
                         {
+                           if ( _zipFileError == nil )
+                           {
+                              [self setErrorCode:ZipErrorCodes.OZCEC_Indeterminate
+                                    errorMessage:ZipErrorCodes.OZCEM_Indeterminate
+                                       andNotify:NO];
+                           }
                         }
                         @finally
                         {

--- a/ObjectiveZipLib/Objective-Zip/ZipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/ZipWithProgress.mm
@@ -106,9 +106,18 @@
    {
       dispatch_async(queue,
                      ^{
-                        [self createZipFile];
-                        [self performZipToolCleanup];
-                        if (completion) completion(_zipFileError);
+                        @try
+                        {
+                           [self createZipFile];
+                           [self performZipToolCleanup];
+                        }
+                        @catch (NSException *exception)
+                        {
+                        }
+                        @finally
+                        {
+                           if (completion) completion(_zipFileError);
+                        }
                      });
    }
    else


### PR DESCRIPTION
Because we execute this asynchronously, we have to hande the exception in the same block.  If you unplug a network drive during an export, an exception is thrown, which was causing a crash.  This will now safely terminate the export and display an error message.