### PR TITLE
Make sure [ZipFile close] is only called once.

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/ZipProgressBase.mm
+++ b/ObjectiveZipLib/Objective-Zip/ZipProgressBase.mm
@@ -78,8 +78,10 @@
 {
    if (_zipTool)
    {
-      [_zipTool close];
+      // make sure we only ever call close once.  close can throw, leaving us in a weird state.
+      ZipFile * tempZipTool = _zipTool;
       _zipTool = nil;
+      [tempZipTool close];
    }
 }
 


### PR DESCRIPTION
close can throw exceptions, which means that the dealloc for ZipWithProgress can throw exceptions.  Because of ARC, dealloc can be called at unpredictable times.  If close throws an exception, the ZipFile is in a weird state, and a second call to close can crash.

I do not catch the exception, because I want the leave that responsibility to the client.
