### PR TITLE
Support unzip into existing folder

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/UnzipFileDelegate.h
+++ b/ObjectiveZipLib/Objective-Zip/UnzipFileDelegate.h
@@ -10,5 +10,6 @@
 
 @protocol UnzipFileDelegate <NSObject>
 @required
-- (BOOL) includeFileWithName:(NSString *) filename error:(NSError * __autoreleasing * ) error;
+-(BOOL) includeFileWithName:(NSString *) filename error:(NSError * __autoreleasing * ) error;
+-(NSString *) modifiedNameForFileName:(NSString *) filename;
 @end

--- a/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.h
+++ b/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.h
@@ -31,7 +31,11 @@
 
 - (BOOL) canUnzipToLocation:(NSURL *)unzipToFolder;
 - (void) unzipToURL:(NSURL *) destinationFolder
+    createNewFolder:(BOOL) createNewFolder
      withCompletionBlock:(void(^)(NSURL * extractionFolder, NSError * error))completion;
+
+- (void) unzipToURL:(NSURL *) destinationFolder
+   withCompletionBlock:(void(^)(NSURL * extractionFolder, NSError * error))completion;
 
 
 @property (weak) NSObject<UnzipFileDelegate> * unzipFileDelegate;

--- a/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
@@ -347,11 +347,18 @@ withCompletionBlock:(void(^)(NSURL * extractionFolder, NSError * error))completi
 {
    BOOL result = NO;
    
+   
    NSURL * fullURL = [unzipToFolder URLByAppendingPathComponent:info.name];
    
    if ([_zipDelegate respondsToSelector:@selector(updateCurrentFile:)])
       [_zipDelegate  updateCurrentFile:fullURL];
    
+   // let the delegate modify the file name.  We do this in all cases, because the delegate may have its own ideas aboutwhat a collision is
+   if ( self.unzipFileDelegate )
+   {
+      fullURL = [unzipToFolder URLByAppendingPathComponent:[self.unzipFileDelegate modifiedNameForFileName:info.name]];
+   }
+
    // create an empty file - don't overwrite an existing file
    NSError * error = nil;
    


### PR DESCRIPTION
This PR adds the ability to use UnzipWithProgress to unzip a file into an existing directory.  The flag createNewFolder controls whether or not UnzipWithProgress creates a folder.  The new delegate method modifiedNameForFileName: allows the client to handle name collisions however it sees fit.