### PR TITLE
Catch exceptions thrown in dealloc

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/ZipProgressBase.mm
+++ b/ObjectiveZipLib/Objective-Zip/ZipProgressBase.mm
@@ -45,7 +45,18 @@
 
 - (void)dealloc
 {
-   [self performZipToolCleanup];
+   @try
+   {
+      [self performZipToolCleanup];
+   }
+   @catch ( NSException * e )
+   {
+      NSLog(@"Exception thrown deallocing ZipProgressBase %@", e);
+   }
+   @catch ( id )
+   {
+      NSLog(@"Exception thrown deallocing ZipProgressBase");
+   }
 }
 
 - (void) setProgressDelegate:(id<ProgressDelegate>)delegate


### PR DESCRIPTION
Because objects can get dealloced at unusual times, and because there is not much to do with the exception anyway, ZipProgressBase will catch any exceptions thrown in its dealloc.  When ZipProgressBase is dealloced, it tries to clean up any files that were open.  If the files were on disks that are no longer available exceptions will be thrown.

This is another attempt to fix the crash we are seeing when exporting a library after having tried to export a library to an external drive and pulling the plug midway.