### PR TITLE
Track created intermediate folders so we clean them up.

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
@@ -367,6 +367,13 @@ withCompletionBlock:(void(^)(NSURL * extractionFolder, NSError * error))completi
    
    if ( ![fileManager fileExistsAtPath:parentURL.path] )
    {
+      NSURL * newFolder = parentURL;
+      do
+      {
+         [self addToFilesCreated:newFolder];
+         newFolder = [newFolder URLByDeletingLastPathComponent];
+      }
+      while ( ![fileManager fileExistsAtPath:newFolder.path]);
       [fileManager createDirectoryAtURL:parentURL withIntermediateDirectories:YES attributes:nil error:&error];
    }
    NSData * emptyData = [NSData new];


### PR DESCRIPTION
This fixes a bug in the C:mac library importer.  If you cancel an import into a library, all the asset files were being deleted, but the intermediate folders were not. This fixes that by adding created intermediate folders to the files created list.