### PR TITLE
Modifications to support linking on import

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/UnzipFileDelegate.h
+++ b/ObjectiveZipLib/Objective-Zip/UnzipFileDelegate.h
@@ -10,6 +10,6 @@
 
 @protocol UnzipFileDelegate <NSObject>
 @required
--(BOOL) includeFileWithName:(NSString *) filename error:(NSError * __autoreleasing * ) error;
+-(BOOL) includeFileWithName:(NSString *) filename forDestinationURL:(NSURL*) destinationURL error:(NSError * __autoreleasing * ) error;
 -(NSString *) modifiedNameForFileName:(NSString *) filename;
 @end

--- a/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
@@ -196,6 +196,7 @@
       }
       else
       {
+         [_zipTool locateFileInZip:info.name];
          [self updateProgress:info.length
                    forFileURL:nil
                  withFileInfo:info
@@ -355,7 +356,7 @@ withCompletionBlock:(void(^)(NSURL * extractionFolder, NSError * error))completi
       [_zipDelegate  updateCurrentFile:fullURL];
    
    // let the delegate modify the file name.  We do this in all cases, because the delegate may have its own ideas aboutwhat a collision is
-   if ( self.unzipFileDelegate )
+   if ( self.unzipFileDelegate && !singleFileOnly )
    {
       fullURL = [unzipToFolder URLByAppendingPathComponent:[self.unzipFileDelegate modifiedNameForFileName:info.name]];
    }

--- a/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
@@ -182,8 +182,9 @@
       FileInZipInfo * info = [_zipTool getCurrentFileInZipInfo];
       
       NSError * error  = nil;
-      if ( !self.unzipFileDelegate || [self.unzipFileDelegate includeFileWithName:info.name error:&error] )
+      if ( !self.unzipFileDelegate || [self.unzipFileDelegate includeFileWithName:info.name forDestinationURL:destinationFolder error:&error] )
       {
+         [_zipTool locateFileInZip:info.name];
          ZipReadStream * readStream = [_zipTool readCurrentFileInZip];
          
          [self extractStream:readStream


### PR DESCRIPTION
This PR makes some modifications to our UnZipWithProgress method in order to support being able to link instead of copy files on import.  The main change is allowing us to import a single file without messing up the import every file case.  We just need to make sure we reset the location within the zip file at the appropriate time.