### PR TITLE
Restore value of createNewFolder after unzipping single file.

### DIFF
--- a/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
+++ b/ObjectiveZipLib/Objective-Zip/UnzipWithProgress.mm
@@ -9,9 +9,29 @@
 #import "ZipException.h"
 #import "ZipFile.h"
 #import "ZipReadStream.h"
-
 #include <set>
 
+
+namespace
+{
+   template<class A>
+   class ScopedSetter
+   {
+   public:
+      ScopedSetter(A * ptr, A newValue) : m_ptr(ptr), m_oldValue(*ptr)
+      {
+         *ptr=newValue;
+      }
+      
+      ~ScopedSetter()
+      {
+         *m_ptr=m_oldValue;
+      }
+      
+      A * m_ptr;
+      A   m_oldValue;
+   };
+}
 
 //
 // UnzipWithProgress private interface
@@ -72,7 +92,7 @@
 {
    static const unsigned long long s_freeSpaceBuffer = 1024 * 1000 * 10; // 10 MB buffer min disk space
    
-   _createNewFolder = YES;
+   ScopedSetter<BOOL> setter(&_createNewFolder, YES);
    
    BOOL result = NO;
    


### PR DESCRIPTION
The createNewFolder flag determines if the unzip process is responsible for creating, and possibly deleting the folder during the unzip process.  This is set to NO when unzipping into a library.  A call to unzipOneFile: was added during the general unzipping process, causing this value to always be set to YES, which meant that cancelling an import into a library would delete the entire library.

It is set to YES in unzipOneFile: so that it cleans up any files it makes in case something goes wrong.

The ScopedSetter code was stolen from GoMediaLib.